### PR TITLE
Typed instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "jinko"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jinko"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["CohenArthur <arthur.cohen@epita.fr>", "Skallwar <esteban.blanc@epita.fr>"]
 edition = "2018"
 description = "jinko is a safe, small and fast programming language with Rust interoperability"

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -19,10 +19,7 @@ impl Indent {
     #[cfg(test)]
     /// Decrement an indent to the next step, stopping at zero spaces
     pub fn decrement(self) -> Indent {
-        match self.0 {
-            0 => Indent(0),
-            _ => Indent(self.0 - Indent::INDENT_STEP),
-        }
+        Indent(self.0.saturating_sub(Indent::INDENT_STEP))
     }
 }
 

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -1,0 +1,75 @@
+//! Helps when formatting indentation and keeping track of it
+
+use std::fmt::Display;
+
+/// Keep and print an indentation level
+#[derive(Default, Copy, Clone)]
+pub struct Indent(usize);
+
+impl Indent {
+    /// Step to increment the indent by
+    const INDENT_STEP: usize = 4;
+
+    /// Increment an indent to the next step, returning a new one
+    pub fn increment(self) -> Indent {
+        Indent(self.0 + Indent::INDENT_STEP)
+    }
+
+    // FIXME: Ugly...
+    #[cfg(test)]
+    /// Decrement an indent to the next step, stopping at zero spaces
+    pub fn decrement(self) -> Indent {
+        match self.0 {
+            0 => Indent(0),
+            _ => Indent(self.0 - Indent::INDENT_STEP),
+        }
+    }
+}
+
+impl Display for Indent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{: <1$}", "", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_indent_nothing() {
+        assert_eq!(format!("{}", Indent::default()), String::new());
+    }
+
+    #[test]
+    fn t_indent_inc() {
+        assert_eq!(
+            format!("{}", Indent::default().increment()),
+            String::from("    ")
+        );
+    }
+
+    #[test]
+    fn t_indent_inc_twice() {
+        assert_eq!(
+            format!("{}", Indent::default().increment().increment()),
+            String::from("        ")
+        );
+    }
+
+    #[test]
+    fn t_indent_inc_dec() {
+        assert_eq!(
+            format!("{}", Indent::default().increment().decrement()),
+            String::new()
+        );
+    }
+
+    #[test]
+    fn t_indent_inc_dec_dec_stops_at_0() {
+        assert_eq!(
+            format!("{}", Indent::default().increment().decrement().decrement()),
+            String::new()
+        );
+    }
+}

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -75,9 +75,8 @@ impl ObjectInstance {
     }
 
     /// Get a reference to the type of the instance
-    // FIXME: Remove clone
-    pub fn ty(&self) -> Option<TypeDec> {
-        self.ty.clone()
+    pub fn ty(&self) -> Option<&TypeDec> {
+        self.ty.as_ref()
     }
 
     /// Set the type of the instance

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -13,8 +13,6 @@ use crate::instruction::TypeDec;
 use crate::{ErrKind, Error, Indent};
 
 pub type Name = String;
-type Ty = Option<TypeDec>;
-type Size = usize;
 type Offset = usize;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -37,8 +35,8 @@ type FieldsMap = HashMap<Name, FieldInstance>;
 /// It's the same as `data.len()`. `data` is the raw byte value of the instance.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ObjectInstance {
-    ty: Ty,
-    size: Size,
+    ty: Option<TypeDec>,
+    size: usize,
     data: Vec<u8>,
     fields: Option<FieldsMap>,
 }
@@ -51,7 +49,7 @@ impl ObjectInstance {
 
     /// Create a new instance
     pub fn new(
-        ty: Ty,
+        ty: Option<TypeDec>,
         size: usize,
         data: Vec<u8>,
         fields: Option<Vec<(Name, ObjectInstance)>>,
@@ -68,7 +66,7 @@ impl ObjectInstance {
 
     /// Create a new instance from raw bytes instead of a vector
     pub fn from_bytes(
-        ty: Ty,
+        ty: Option<TypeDec>,
         size: usize,
         data: &[u8],
         fields: Option<Vec<(Name, ObjectInstance)>>,
@@ -83,7 +81,7 @@ impl ObjectInstance {
     }
 
     /// Set the type of the instance
-    pub fn set_ty(&mut self, ty: Ty) {
+    pub fn set_ty(&mut self, ty: Option<TypeDec>) {
         self.ty = ty;
     }
 
@@ -92,7 +90,7 @@ impl ObjectInstance {
         &self.data
     }
 
-    pub fn size(&self) -> Size {
+    pub fn size(&self) -> usize {
         self.size
     }
 
@@ -113,7 +111,6 @@ impl ObjectInstance {
         &self.fields
     }
 
-    // FIXME: Isn't this disgusting
     fn fields_vec_to_hash_map(vec: Vec<(Name, ObjectInstance)>) -> FieldsMap {
         let mut current_offset: usize = 0;
         let mut hashmap = FieldsMap::new();
@@ -153,7 +150,6 @@ impl ObjectInstance {
         base
     }
 
-    // FIXME: Remove this
     pub fn as_string(&self) -> String {
         ObjectInstance::as_string_inner(self, Indent::default())
     }

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -20,6 +20,16 @@ type Offset = usize;
 #[derive(Debug, PartialEq, Clone)]
 pub struct FieldInstance(Offset, ObjectInstance);
 
+impl FieldInstance {
+    pub fn offset(&self) -> &Offset {
+        &self.0
+    }
+
+    pub fn instance(&self) -> &ObjectInstance {
+        &self.1
+    }
+}
+
 type FieldsMap = HashMap<Name, FieldInstance>;
 
 /// The type is optional. At first, the type might not be known, and will only be

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -100,9 +100,7 @@ mod tests {
             None => return assert!(false, "Error when accessing valid field"),
         };
 
-        let mut exp = JkInt::from(15).to_instance();
-        // FIXME: Remove once TypeInstantiations create typed instances
-        exp.set_ty(None);
+        let exp = JkInt::from(15).to_instance();
 
         assert_eq!(res, exp)
     }
@@ -119,9 +117,7 @@ mod tests {
             None => unreachable!("Error when accesing valid field"),
         };
 
-        let mut exp = JkInt::from(1).to_instance();
-        // FIXME: Remove once TypeInstantiations create typed instances
-        exp.set_ty(None);
+        let exp = JkInt::from(1).to_instance();
 
         assert_eq!(res, exp)
     }

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -5,7 +5,7 @@ use super::{
     Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, Rename, TypeDec, TypeId,
     VarAssign,
 };
-use crate::instance::{Name, Size, Ty};
+use crate::instance::Name;
 
 use std::rc::Rc;
 
@@ -118,20 +118,18 @@ impl Instruction for TypeInstantiation {
 
         let mut size: usize = 0;
         let mut data: Vec<u8> = Vec::new();
-        let mut fields: Vec<(Name, (Ty, Size))> = Vec::new();
+        let mut fields: Vec<(Name, ObjectInstance)> = Vec::new();
         for (_, named_arg) in self.fields.iter().enumerate() {
             // FIXME: Need to assign the correct field to the field that corresponds
             // in the typedec
             let field_instr = named_arg.value();
             let field_name = named_arg.symbol();
 
-            // FIXME: Use execute_expression() here?
             let instance = field_instr.execute_expression(ctx)?;
+            size += instance.size();
 
-            let inst_size = instance.size();
-            size += inst_size;
-            fields.push((field_name.to_string(), (instance.ty(), instance.size())));
             data.append(&mut instance.data().to_vec());
+            fields.push((field_name.to_string(), instance));
         }
 
         Some(ObjectInstance::new(

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -154,6 +154,8 @@ impl Rename for TypeInstantiation {
 
 #[cfg(test)]
 mod test {
+    use crate::instance::FieldInstance;
+
     use super::*;
 
     #[test]
@@ -258,8 +260,9 @@ mod test {
         );
         assert_eq!(instance.size(), 33);
 
-        assert_eq!(instance.fields().as_ref().unwrap().get("a"), Some(&(0, 25)));
-        assert_eq!(instance.fields().as_ref().unwrap().get("b"), Some(&(25, 8)));
+        // FIXME: Is this a valid test?
+        assert_eq!(instance.fields().as_ref().unwrap().get("a").unwrap().offset(), &0usize);
+        assert_eq!(instance.fields().as_ref().unwrap().get("b").unwrap().offset(), &25usize);
     }
 
     #[test]

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -259,8 +259,26 @@ mod test {
         assert_eq!(instance.size(), 33);
 
         // FIXME: Is this a valid test?
-        assert_eq!(instance.fields().as_ref().unwrap().get("a").unwrap().offset(), &0usize);
-        assert_eq!(instance.fields().as_ref().unwrap().get("b").unwrap().offset(), &25usize);
+        assert_eq!(
+            instance
+                .fields()
+                .as_ref()
+                .unwrap()
+                .get("a")
+                .unwrap()
+                .offset(),
+            &0usize
+        );
+        assert_eq!(
+            instance
+                .fields()
+                .as_ref()
+                .unwrap()
+                .get("b")
+                .unwrap()
+                .offset(),
+            &25usize
+        );
     }
 
     #[test]

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -5,7 +5,7 @@ use super::{
     Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, Rename, TypeDec, TypeId,
     VarAssign,
 };
-use crate::instance::{Name, Size};
+use crate::instance::{Name, Size, Ty};
 
 use std::rc::Rc;
 
@@ -118,7 +118,7 @@ impl Instruction for TypeInstantiation {
 
         let mut size: usize = 0;
         let mut data: Vec<u8> = Vec::new();
-        let mut fields: Vec<(Name, Size)> = Vec::new();
+        let mut fields: Vec<(Name, (Ty, Size))> = Vec::new();
         for (_, named_arg) in self.fields.iter().enumerate() {
             // FIXME: Need to assign the correct field to the field that corresponds
             // in the typedec
@@ -130,7 +130,7 @@ impl Instruction for TypeInstantiation {
 
             let inst_size = instance.size();
             size += inst_size;
-            fields.push((field_name.to_string(), inst_size));
+            fields.push((field_name.to_string(), (instance.ty(), instance.size())));
             data.append(&mut instance.data().to_vec());
         }
 

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -154,8 +154,6 @@ impl Rename for TypeInstantiation {
 
 #[cfg(test)]
 mod test {
-    use crate::instance::FieldInstance;
-
     use super::*;
 
     #[test]

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -58,10 +58,7 @@ impl Instruction for Var {
         format!(
             "{} /* : {} = {} */",
             self.name.clone(),
-            self.instance
-                .ty()
-                .unwrap_or_else(|| TypeDec::from(""))
-                .name(),
+            self.instance.ty().unwrap_or(&TypeDec::from("")).name(),
             self.instance
         )
     }

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -58,7 +58,7 @@ impl Instruction for Var {
         format!(
             "{} /* : {} = {} */",
             self.name.clone(),
-            self.instance.ty().unwrap_or(&TypeDec::from("")).name(),
+            self.instance.ty().unwrap_or(TypeDec::from("")).name(),
             self.instance
         )
     }

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -58,7 +58,10 @@ impl Instruction for Var {
         format!(
             "{} /* : {} = {} */",
             self.name.clone(),
-            self.instance.ty().unwrap_or(TypeDec::from("")).name(),
+            self.instance
+                .ty()
+                .unwrap_or_else(|| TypeDec::from(""))
+                .name(),
             self.instance
         )
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 mod args;
 mod context;
 mod error;
+mod indent;
 mod instance;
 mod instruction;
 mod parser;
@@ -16,6 +17,7 @@ use std::{fs, path::Path};
 
 pub use context::Context;
 pub use error::{ErrKind, Error};
+pub use indent::Indent;
 pub use instance::{FromObjectInstance, ObjectInstance, ToObjectInstance};
 pub use instruction::{InstrKind, Instruction, Rename};
 pub use value::{JkBool, JkChar, JkConstant, JkFloat, JkInt, JkString, Value};

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -16,6 +16,7 @@ use crate::{
 // FIXME:
 // - Is Display really how we want to go about it?
 // - Cleanup the code
+// - This should not be here
 impl std::fmt::Display for ObjectInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -28,7 +29,7 @@ impl std::fmt::Display for ObjectInstance {
                     "char" => JkConstant::<char>::from_instance(self).print(),
                     "string" => JkConstant::<String>::from_instance(self).print(),
                     "bool" => JkConstant::<bool>::from_instance(self).print(),
-                    _ => format!("{:?}", self),
+                    _ => self.as_string(),
                 },
                 None => format!(""),
             }


### PR DESCRIPTION
This PR adds more typing to instances. Instead of simply keeping track of the offset and size of the data and fields, we can also keep track of the instance in itself. This is slower but helps keep more information that we might need (such as the type of said instance)