### PR TITLE
Rework parser

### DIFF
--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -81,11 +81,12 @@ impl Instruction for JkInst {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::Construct;
+    use crate::parser::{Construct, Token};
 
     #[test]
     fn t_invalid_jkinst() {
-        let (_, fc) = Construct::function_call("tamer()").unwrap();
+        let (input, id) = Token::identifier("tamer()").unwrap();
+        let (_, fc) = Construct::function_call(input, &id).unwrap();
         let inst = JkInst::from_function_call(fc);
 
         assert!(inst.is_err(), "tamer is not a valid ctx directive")
@@ -93,7 +94,8 @@ mod tests {
 
     #[test]
     fn t_valid_inst_no_args() {
-        let (_, fc) = Construct::function_call("dump()").unwrap();
+        let (input, id) = Token::identifier("dump()").unwrap();
+        let (_, fc) = Construct::function_call(input, &id).unwrap();
         let inst = JkInst::from_function_call(fc);
 
         assert!(inst.is_ok(), "dump is a valid ctx directive")
@@ -101,7 +103,8 @@ mod tests {
 
     #[test]
     fn t_valid_inst_with_args() {
-        let (_, fc) = Construct::function_call("ir(fn)").unwrap();
+        let (input, id) = Token::identifier("ir(fn)").unwrap();
+        let (_, fc) = Construct::function_call(input, &id).unwrap();
         let inst = JkInst::from_function_call(fc);
 
         assert!(

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -141,6 +141,7 @@ mod tests {
         let mut i = Context::new();
         let va_init = Construct::mut_var_assignment("mut a = 13").unwrap().1;
         let (input, id) = Token::identifier("a = 15").unwrap();
+        let (input, _) = Token::maybe_consume_extra(input).unwrap();
         let va_0 = Construct::var_assignment(input, &id).unwrap().1;
 
         va_init.execute(&mut i);
@@ -157,8 +158,10 @@ mod tests {
     fn assign_immutable() {
         let mut i = Context::new();
         let (input, id) = Token::identifier("a = 13").unwrap();
+        let (input, _) = Token::maybe_consume_extra(input).unwrap();
         let va_init = Construct::var_assignment(input, &id).unwrap().1;
         let (input, id) = Token::identifier("a = 1b").unwrap();
+        let (input, _) = Token::maybe_consume_extra(input).unwrap();
         let va_0 = Construct::var_assignment(input, &id).unwrap().1;
 
         va_init.execute(&mut i);

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -37,6 +37,11 @@ impl VarAssign {
     pub fn value(&self) -> &dyn Instruction {
         &*self.value
     }
+
+    /// Set VarAssign mutability
+    pub fn set_mutable(&mut self, is_mutable: bool) {
+        self.mutable = is_mutable;
+    }
 }
 
 impl Instruction for VarAssign {
@@ -109,7 +114,7 @@ impl Instruction for VarAssign {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::Construct;
+    use crate::parser::{Construct, Token};
     use crate::value::{JkInt, JkString};
     use crate::ToObjectInstance;
 
@@ -134,8 +139,9 @@ mod tests {
     #[test]
     fn assign_mutable() {
         let mut i = Context::new();
-        let va_init = Construct::var_assignment("mut a = 13").unwrap().1;
-        let va_0 = Construct::var_assignment("a = 15").unwrap().1;
+        let va_init = Construct::mut_var_assignment("mut a = 13").unwrap().1;
+        let (input, id) = Token::identifier("a = 15").unwrap();
+        let va_0 = Construct::var_assignment(input, &id).unwrap().1;
 
         va_init.execute(&mut i);
         va_0.execute(&mut i);
@@ -150,8 +156,10 @@ mod tests {
     #[test]
     fn assign_immutable() {
         let mut i = Context::new();
-        let va_init = Construct::var_assignment("a = 13").unwrap().1;
-        let va_0 = Construct::var_assignment("a = 15").unwrap().1;
+        let (input, id) = Token::identifier("a = 13").unwrap();
+        let va_init = Construct::var_assignment(input, &id).unwrap().1;
+        let (input, id) = Token::identifier("a = 1b").unwrap();
+        let va_0 = Construct::var_assignment(input, &id).unwrap().1;
 
         va_init.execute(&mut i);
         if va_0.execute(&mut i).is_some() {
@@ -164,8 +172,8 @@ mod tests {
     #[test]
     fn create_mutable_twice() {
         let mut i = Context::new();
-        let va_init = Construct::var_assignment("mut a = 13").unwrap().1;
-        let va_0 = Construct::var_assignment("mut a = 15").unwrap().1;
+        let va_init = Construct::mut_var_assignment("mut a = 13").unwrap().1;
+        let va_0 = Construct::mut_var_assignment("mut a = 15").unwrap().1;
 
         va_init.execute(&mut i);
         if va_0.execute(&mut i).is_some() {

--- a/src/parser/box_construct.rs
+++ b/src/parser/box_construct.rs
@@ -62,4 +62,12 @@ impl BoxConstruct {
         let (input, assignment) = Construct::var_assignment(input, var_name)?;
         Ok((input, Box::new(assignment)))
     }
+
+    pub fn _function_call<'a>(
+        input: &'a str,
+        var_name: &str,
+    ) -> ParseResult<&'a str, Box<dyn Instruction>> {
+        let (input, assignment) = Construct::_function_call(input, var_name)?;
+        Ok((input, Box::new(assignment)))
+    }
 }

--- a/src/parser/box_construct.rs
+++ b/src/parser/box_construct.rs
@@ -52,8 +52,6 @@ impl BoxConstruct {
     box_construct! {test_declaration}
     box_construct! {mock_declaration}
     box_construct! {incl}
-    box_construct! {method_call}
-    box_construct! {field_access}
     box_construct! {extra}
     box_construct! {jk_return}
 }

--- a/src/parser/box_construct.rs
+++ b/src/parser/box_construct.rs
@@ -46,7 +46,7 @@ impl BoxConstruct {
     box_construct! {block}
     box_construct! {jinko_inst}
     box_construct! {any_loop}
-    box_construct! {var_assignment}
+    box_construct! {mut_var_assignment}
     box_construct! {if_else}
     box_construct! {type_declaration}
     box_construct! {test_declaration}
@@ -54,4 +54,12 @@ impl BoxConstruct {
     box_construct! {incl}
     box_construct! {extra}
     box_construct! {jk_return}
+
+    pub fn var_assignment<'a>(
+        input: &'a str,
+        var_name: &str,
+    ) -> ParseResult<&'a str, Box<dyn Instruction>> {
+        let (input, assignment) = Construct::var_assignment(input, var_name)?;
+        Ok((input, Box::new(assignment)))
+    }
 }

--- a/src/parser/box_construct.rs
+++ b/src/parser/box_construct.rs
@@ -39,10 +39,8 @@ impl BoxConstruct {
     }
 
     box_construct! {type_instantiation}
-    box_construct! {function_call}
     box_construct! {function_declaration}
     box_construct! {ext_declaration}
-    box_construct! {variable}
     box_construct! {block}
     box_construct! {jinko_inst}
     box_construct! {any_loop}
@@ -63,11 +61,11 @@ impl BoxConstruct {
         Ok((input, Box::new(assignment)))
     }
 
-    pub fn _function_call<'a>(
+    pub fn function_call<'a>(
         input: &'a str,
         var_name: &str,
     ) -> ParseResult<&'a str, Box<dyn Instruction>> {
-        let (input, assignment) = Construct::_function_call(input, var_name)?;
+        let (input, assignment) = Construct::function_call(input, var_name)?;
         Ok((input, Box::new(assignment)))
     }
 }

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -38,9 +38,10 @@ impl Construct {
         // has been parsed
         let (input, value) = alt((
             BoxConstruct::extra,
-            Construct::method_call_or_field_access,
-            // binary_op must be parsed before variable and constant
+            // binary_op must be parsed before variables, constants, function calls and
+            // method_calls
             Construct::binary_op,
+            Construct::method_call_or_field_access,
             Construct::type_inst_or_function_call_or_var,
             BoxConstruct::function_declaration,
             BoxConstruct::type_declaration,

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -61,8 +61,8 @@ impl Construct {
 
     /// Parse a method call or a field access
     ///
-    /// method_call_or_field_access = instance '.' method_call
-    ///                             | instance '.' field_access
+    /// method_call_or_field_access = instance '.' identifer method_call
+    ///                             | instance '.' identifer field_access
     pub fn method_call_or_field_access(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
         let (input, instance) = Construct::instance(input)?;
         let (input, _) = Token::dot(input)?;
@@ -86,7 +86,7 @@ impl Construct {
 
     /// Parse a field access
     ///
-    /// identifer ( '.' identifier )*
+    /// ( '.' identifier )*
     pub fn field_access(
         input: &str,
         first_fa: Box<dyn Instruction>,

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -61,8 +61,8 @@ impl Construct {
 
     /// Parse a method call or a field access
     ///
-    /// method_call_or_field_access = instance '.' identifer method_call
-    ///                             | instance '.' identifer field_access
+    /// method_call_or_field_access = instance '.' identifier method_call
+    ///                             | instance '.' identifier field_access
     pub fn method_call_or_field_access(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
         let (input, instance) = Construct::instance(input)?;
         let (input, _) = Token::dot(input)?;

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -38,11 +38,6 @@ impl Construct {
         // has been parsed
         let (input, value) = alt((
             BoxConstruct::extra,
-            // binary_op must be parsed before variables, constants, function calls and
-            // method_calls
-            Construct::binary_op,
-            Construct::method_call_or_field_access,
-            Construct::type_inst_or_function_call_or_var,
             BoxConstruct::function_declaration,
             BoxConstruct::type_declaration,
             BoxConstruct::ext_declaration,
@@ -54,6 +49,11 @@ impl Construct {
             BoxConstruct::jinko_inst,
             BoxConstruct::block,
             BoxConstruct::mut_var_assignment,
+            // binary_op must be parsed before variables, constants, function calls and
+            // method_calls
+            Construct::binary_op,
+            Construct::method_call_or_field_access,
+            Construct::type_inst_or_function_call_or_var,
             Construct::constant,
         ))(input)?;
 

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -47,13 +47,13 @@ impl Construct {
             BoxConstruct::if_else,
             BoxConstruct::any_loop,
             BoxConstruct::jinko_inst,
-            BoxConstruct::block,
             BoxConstruct::mut_var_assignment,
             // binary_op must be parsed before variables, constants, function calls and
             // method_calls
             Construct::binary_op,
             Construct::method_call_or_field_access,
             Construct::type_inst_or_function_call_or_var,
+            BoxConstruct::block,
             Construct::constant,
         ))(input)?;
 

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -68,7 +68,7 @@ impl Construct {
         let (input, instance) = Construct::instance(input)?;
         let (input, _) = Token::dot(input)?;
         let (input, field_name) = Token::identifier(input)?;
-        Construct::method_call(input, &instance, &field_name)
+        Construct::method_call(input, instance.clone(), &field_name)
             .or_else(|_| Construct::field_access(input, instance, field_name))
     }
 
@@ -77,12 +77,12 @@ impl Construct {
     /// function_call
     pub fn method_call<'a>(
         input: &'a str,
-        caller: &Box<dyn Instruction>,
+        caller: Box<dyn Instruction>,
         field_name: &str,
     ) -> ParseResult<&'a str, Box<dyn Instruction>> {
         let (input, method) = Construct::function_call(input, field_name)?;
 
-        Ok((input, Box::new(MethodCall::new(caller.clone(), method))))
+        Ok((input, Box::new(MethodCall::new(caller, method))))
     }
 
     /// Parse a field access

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -1,4 +1,4 @@
-instruction = binary_op
+instruction = maybe_consume_extra [ binary_op
               | method_call
               | field_access
               | function_declaration
@@ -16,7 +16,7 @@ instruction = binary_op
               | var_assignment
               | variable
               | constant
-              | extra
+              | extra ]
 
 
 (* BINARY_OP *)
@@ -30,13 +30,8 @@ binary_op = ? shunting-yard algorithm ?
 
 method_call = method_caller '.' function_call
 
-method_caller = function_call
-              | variable
+method_caller = instance
               | constant
-              | if_else
-              | block
-              | any_loop
-              | jinko_inst
 
 
 (* FIELD_ACCESS *)
@@ -60,7 +55,7 @@ function_content = maybe_consume_extra identifier maybe_consume_extra args_dec r
 (* TYPE_DECLARATION *)
 
 
-type_declaration = maybe_consume_extra 'type' maybe_consume_extra identifier maybe_consume_extra args_dec_non_empty
+type_declaration = 'type' maybe_consume_extra identifier maybe_consume_extra args_dec_non_empty
 
 
 (* EXT_DECLARATION *)
@@ -104,7 +99,7 @@ arg = maybe_consume_extra instruction maybe_consume_extra
 (* INCL *)
 
 
-incl = maybe_consume_extra 'incl' path az_identifier maybe_consume_extra
+incl = 'incl' path az_identifier maybe_consume_extra
 
 path = maybe_consume_extra identifier maybe_consume_extra
 
@@ -114,7 +109,7 @@ az_identifier = maybe_consume_extra [ 'as' maybe_consume_extra identifier ] mayb
 (* IF_ELSE *)
 
 
-if_else = maybe_consume_extra 'if' maybe_consume_extra instruction maybe_consume_extra block [ else_block ]
+if_else = 'if' maybe_consume_extra instruction maybe_consume_extra block [ else_block ]
 
 else_block = maybe_consume_extra 'else' maybe_consume_extra block
 
@@ -126,11 +121,11 @@ any_loop = loop_block
          | for_block
          | while_block
 
-loop_block = maybe_consume_extra 'loop' maybe_consume_extra block
+loop_block = 'loop' maybe_consume_extra block
 
-for_block = maybe_consume_extra 'for' maybe_consume_extra variable maybe_consume_extra 'in' maybe_consume_extra instruction maybe_consume_extra block
+for_block = 'for' maybe_consume_extra variable maybe_consume_extra 'in' maybe_consume_extra instruction maybe_consume_extra block
 
-while_block = maybe_consume_extra 'while' maybe_consume_extra instruction maybe_consume_extra block
+while_block = 'while' maybe_consume_extra instruction maybe_consume_extra block
 
 
 
@@ -204,3 +199,11 @@ return_type_non_void = maybe_consume_extra '->' identifier maybe_consume_extra
 
 maybe_consume_extra = comment
                     | whitespace
+
+instance = function_call
+         | type_instantiation
+         | variable
+         | if_else
+         | block
+         | any_loop
+         | jinko_inst

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -1,47 +1,34 @@
-instruction = maybe_consume_extra [ binary_op
-              | method_call
-              | field_access
-              | function_declaration
-              | type_declaration
-              | ext_declaration
-              | test_declaration
-              | mock_declaration
-              | type_instantiation
-              | function_call
-              | incl
-              | if_else
-              | any_loop
-              | jinko_inst
-              | block
-              | var_assignment
-              | variable
-              | constant
-              | extra ]
+instruction = extra
+            | method_call_or_field_access
+            | identifier maybe_consume_extra '{' named_arg_list '}'
+            | identifier '(' maybe_consume_extra [ args_list ] ')'
+            | identifier
+            | binary_op
+            | function_declaration
+            | type_declaration
+            | ext_declaration
+            | test_declaration
+            | mock_declaration
+            | incl
+            | if_else
+            | any_loop
+            | jinko_inst
+            | block
+            | var_assignment
+            | constant
+
+method_call_or_field_access = instance '.' method_call
+                            | instance '.' field_access
+
+method_call = function_call
+
+field_access = identifier ( '.' identifier )*
 
 
 (* BINARY_OP *)
 
 
 binary_op = ? shunting-yard algorithm ?
-
-
-(* METHOD_CALL *)
-
-
-method_call = method_caller '.' function_call
-
-method_caller = instance
-              | constant
-
-
-(* FIELD_ACCESS *)
-
-
-field_access = inner_field_access ( dot_field )*
-
-inner_field_access = instance dot_field 
-
-dot_field = '.' identifier
 
 
 (* FUNCTION_DECLARATION *)

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -17,7 +17,7 @@ instruction = extra
 method_call_or_field_access = instance '.' identifier method_call
                             | instance '.' identifier field_access
 
-method_call = _function_call
+method_call = function_call
 
 field_access = ( '.' identifier )*
 
@@ -34,6 +34,7 @@ type_instantiation = maybe_consume_extra '{' named_arg_list '}'
 var_assignment = maybe_consume_extra '=' maybe_consume_extra instruction
 
 mut var_assignment = 'mut' maybe_consume_extra identifier var_assignment
+
 
 (* BINARY_OP *)
 
@@ -76,8 +77,6 @@ mock_declaration = 'mock' function_content
 (* TYPE_INSTANTIATION *)
 
 
-type_instantiation = identifier maybe_consume_extra '{' named_arg_list '}'
-
 named_arg_list = ( named_arg ',' )* named_arg
 
 named_arg = maybe_consume_extra identifier maybe_consume_extra '=' maybe_consume_extra instruction maybe_consume_extra
@@ -85,8 +84,6 @@ named_arg = maybe_consume_extra identifier maybe_consume_extra '=' maybe_consume
 
 (* FUNCTION_CALL *)
 
-
-function_call = identifier '(' maybe_consume_extra [ args_list ] ')'
 
 args_list = arg maybe_consume_extra ( ',' maybe_consume_extra instruction maybe_consume_extra )*
 
@@ -142,18 +139,6 @@ block_instruction = '{' maybe_consume_extra stmts_and_maybe_last maybe_consume_e
 stmts_and_maybe_last = ( stmt_semicolon )* ( early_return | instruction )
 
 early_return = maybe_consume_extra 'return' maybe_consume_extra [instruction] maybe_consume_extra [ ';' ]
-
-
-(* VAR_ASSIGNMENT *)
-
-
-var_assignment = [ 'mut' ] maybe_consume_extra identifier maybe_consume_extra '=' maybe_consume_extra instruction
-
-
-(* VARIABLE *)
-
-
-variable = identifier
 
 
 (* CONSTANT *)

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -1,0 +1,206 @@
+instruction = binary_op
+              | method_call
+              | field_access
+              | function_declaration
+              | type_declaration
+              | ext_declaration
+              | test_declaration
+              | mock_declaration
+              | type_instantiation
+              | function_call
+              | incl
+              | if_else
+              | any_loop
+              | jinko_inst
+              | block
+              | var_assignment
+              | variable
+              | constant
+              | extra
+
+
+(* BINARY_OP *)
+
+
+binary_op = ? shunting-yard algorithm ?
+
+
+(* METHOD_CALL *)
+
+
+method_call = method_caller '.' function_call
+
+method_caller = function_call
+              | variable
+              | constant
+              | if_else
+              | block
+              | any_loop
+              | jinko_inst
+
+
+(* FIELD_ACCESS *)
+
+
+field_access = inner_field_access ( dot_field )*
+
+inner_field_access = instance dot_field 
+
+dot_field = '.' identifier
+
+
+(* FUNCTION_DECLARATION *)
+
+
+function_declaration = 'func' function_content
+
+function_content = maybe_consume_extra identifier maybe_consume_extra args_dec return_type block
+
+
+(* TYPE_DECLARATION *)
+
+
+type_declaration = maybe_consume_extra 'type' maybe_consume_extra identifier maybe_consume_extra args_dec_non_empty
+
+
+(* EXT_DECLARATION *)
+
+
+ext_declaration = 'ext' maybe_consume_extra 'func' maybe_consume_extra identifier maybe_consume_extra args_dec return_type maybe_consume_extra ';'
+
+
+(* TEST_DECLARATION *)
+
+
+test_declaration = 'test' maybe_consume_extra identifier maybe_consume_extra args_dec return_type_void block
+
+
+(* MOCK_DECLARATION *)
+
+
+mock_declaration = 'mock' function_content
+
+
+(* TYPE_INSTANTIATION *)
+
+
+type_instantiation = identifier maybe_consume_extra '{' named_arg_list '}'
+
+named_arg_list = ( named_arg ',' )* named_arg
+
+named_arg = maybe_consume_extra identifier maybe_consume_extra '=' maybe_consume_extra instruction maybe_consume_extra
+
+
+(* FUNCTION_CALL *)
+
+
+function_call = identifier '(' maybe_consume_extra [ args_list ] ')'
+
+args_list = arg maybe_consume_extra ( ',' maybe_consume_extra instruction maybe_consume_extra )*
+
+arg = maybe_consume_extra instruction maybe_consume_extra
+
+
+(* INCL *)
+
+
+incl = maybe_consume_extra 'incl' path az_identifier maybe_consume_extra
+
+path = maybe_consume_extra identifier maybe_consume_extra
+
+az_identifier = maybe_consume_extra [ 'as' maybe_consume_extra identifier ] maybe_consume_extra
+
+
+(* IF_ELSE *)
+
+
+if_else = maybe_consume_extra 'if' maybe_consume_extra instruction maybe_consume_extra block [ else_block ]
+
+else_block = maybe_consume_extra 'else' maybe_consume_extra block
+
+
+(* ANY_LOOP *)
+
+
+any_loop = loop_block
+         | for_block
+         | while_block
+
+loop_block = maybe_consume_extra 'loop' maybe_consume_extra block
+
+for_block = maybe_consume_extra 'for' maybe_consume_extra variable maybe_consume_extra 'in' maybe_consume_extra instruction maybe_consume_extra block
+
+while_block = maybe_consume_extra 'while' maybe_consume_extra instruction maybe_consume_extra block
+
+
+
+(* JINKO_INST *)
+
+
+jinko_inst = '@' function_call
+
+
+(* BLOCK *)
+
+
+block = block_instruction
+
+block_instruction = '{' maybe_consume_extra stmts_and_maybe_last maybe_consume_extra [ instruction ] (* error if instruction here *) '}'
+
+stmts_and_maybe_last = ( stmt_semicolon )* ( early_return | instruction )
+
+early_return = maybe_consume_extra 'return' maybe_consume_extra [instruction] maybe_consume_extra [ ';' ]
+
+
+(* VAR_ASSIGNMENT *)
+
+
+var_assignment = [ 'mut' ] maybe_consume_extra identifier maybe_consume_extra '=' maybe_consume_extra instruction
+
+
+(* VARIABLE *)
+
+
+variable = identifier
+
+
+(* CONSTANT *)
+
+
+constant = char_constant
+         | string_constant
+         | int_constant
+         | float_constant
+         | bool_constant
+
+
+(* EXTRA *)
+
+
+extra = extra_whitespace
+      | extra_shebang
+      | extra_single
+      | extra_multi
+
+
+
+(* MISC_DECLARATION *)
+
+
+args_dec = args_dec_empty
+         | args_dec_non_empty
+
+args_dec_empty = '(' maybe_consume_extra ')'
+
+args_dec_non_empty = '(' maybe_consume_extra ( identifier_type_comma )* identifier ')'
+
+return_type = return_type_void
+            | return_type_non_void
+
+return_type_void = maybe_consume_extra [ '->' ] (* error if -> present *)
+
+return_type_non_void = maybe_consume_extra '->' identifier maybe_consume_extra
+
+
+maybe_consume_extra = comment
+                    | whitespace

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -1,6 +1,7 @@
 instruction = extra
             | method_call_or_field_access
             | binary_op
+            | type_inst_or_function_call_or_variable
             | function_declaration
             | type_declaration
             | ext_declaration
@@ -11,7 +12,7 @@ instruction = extra
             | any_loop
             | jinko_inst
             | block
-            | var_assignment
+            | mut_var_assignment
             | constant
 
 method_call_or_field_access = instance '.' identifier method_call
@@ -22,18 +23,18 @@ method_call = function_call
 field_access = ( '.' identifier )*
 
 
-type_inst_or_function_call_or_variable = identifier function_call
-                                       | identifier type_instantiation
-                                       | identifier var_assignment
+type_inst_or_function_call_or_variable = identifier maybe_consume_extra function_call
+                                       | identifier maybe_consume_extra type_instantiation
+                                       | identifier maybe_consume_extra var_assignment
                                        | identifier (* variable *)
 
 function_call = '(' maybe_consume_extra [ args_list ] ')'
 
-type_instantiation = maybe_consume_extra '{' named_arg_list '}'
+type_instantiation = '{' named_arg_list '}'
 
-var_assignment = maybe_consume_extra '=' maybe_consume_extra instruction
+var_assignment = '=' maybe_consume_extra instruction
 
-mut var_assignment = 'mut' maybe_consume_extra identifier var_assignment
+mut_var_assignment = 'mut' maybe_consume_extra identifier maybe_consume_extra var_assignment
 
 
 (* BINARY_OP *)

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -1,8 +1,5 @@
 instruction = extra
             | method_call_or_field_access
-            | identifier maybe_consume_extra '{' named_arg_list '}'
-            | identifier '(' maybe_consume_extra [ args_list ] ')'
-            | identifier
             | binary_op
             | function_declaration
             | type_declaration
@@ -24,6 +21,19 @@ method_call = function_call
 
 field_access = identifier ( '.' identifier )*
 
+
+type_inst_or_function_call_or_variable = identifier function_call
+                                       | identifier type_instantiation
+                                       | identifier var_assignment
+                                       | identifier (* variable *)
+
+function_call = '(' maybe_consume_extra [ args_list ] ')'
+
+type_instantiation = maybe_consume_extra '{' named_arg_list '}'
+
+var_assignment = maybe_consume_extra '=' maybe_consume_extra instruction
+
+mut var_assignment = 'mut' maybe_consume_extra identifier var_assignment
 
 (* BINARY_OP *)
 

--- a/src/parser/ebnf_grammar
+++ b/src/parser/ebnf_grammar
@@ -14,12 +14,12 @@ instruction = extra
             | var_assignment
             | constant
 
-method_call_or_field_access = instance '.' method_call
-                            | instance '.' field_access
+method_call_or_field_access = instance '.' identifier method_call
+                            | instance '.' identifier field_access
 
-method_call = function_call
+method_call = _function_call
 
-field_access = identifier ( '.' identifier )*
+field_access = ( '.' identifier )*
 
 
 type_inst_or_function_call_or_variable = identifier function_call

--- a/src/parser/shunting_yard.rs
+++ b/src/parser/shunting_yard.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{ErrKind, Error};
 use crate::instruction::{BinaryOp, Instruction, Operator};
-use crate::parser::{BoxConstruct, Construct, ParseResult, Token};
+use crate::parser::{Construct, ParseResult, Token};
 use crate::utils::{Queue, Stack};
 
 use nom::branch::alt;

--- a/src/parser/shunting_yard.rs
+++ b/src/parser/shunting_yard.rs
@@ -79,10 +79,9 @@ impl ShuntingYard {
 
     fn operand<'i>(&mut self, input: &'i str) -> ParseResult<&'i str, ()> {
         let (input, expr) = alt((
+            Construct::function_call_or_var,
             Construct::method_call_or_field_access,
-            BoxConstruct::function_call,
             Construct::constant,
-            BoxConstruct::variable,
         ))(input)?;
 
         self.output.push(SyPair::Num(expr));

--- a/src/parser/shunting_yard.rs
+++ b/src/parser/shunting_yard.rs
@@ -79,7 +79,7 @@ impl ShuntingYard {
 
     fn operand<'i>(&mut self, input: &'i str) -> ParseResult<&'i str, ()> {
         let (input, expr) = alt((
-            BoxConstruct::method_call,
+            Construct::method_call_or_field_access,
             BoxConstruct::function_call,
             Construct::constant,
             BoxConstruct::variable,

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -370,11 +370,10 @@ impl Token {
 
     /// Consumes 1 or more whitespaces in an input. A whitespace is a space, a tab or a newline
     pub fn consume_whitespaces(input: &str) -> ParseResult<&str, &str> {
-        let ws = take_while1(Token::is_whitespace)(input)?;
-
-        Ok(ws)
+        take_while1(Token::is_whitespace)(input)
     }
 
+    #[inline(always)]
     pub fn consume_multi_comment(input: &str) -> ParseResult<&str, &str> {
         let (input, _) = Token::comment_multi_start(input)?;
         let (input, content) = take_until("*/")(input)?;
@@ -383,6 +382,7 @@ impl Token {
         Ok((input, content))
     }
 
+    #[inline(always)]
     pub fn consume_single_comment(input: &str) -> ParseResult<&str, &str> {
         let (input, _) = Token::comment_single(input)?;
         let comment = take_while(|c| c != '\n' && c != '\0')(input)?;
@@ -390,6 +390,7 @@ impl Token {
         Ok(comment)
     }
 
+    #[inline(always)]
     pub fn consume_shebang_comment(input: &str) -> ParseResult<&str, &str> {
         let (input, _) = Token::comment_shebang(input)?;
         let comment = take_while(|c| c != '\n' && c != '\0')(input)?;
@@ -399,13 +400,11 @@ impl Token {
 
     /// Consumes all kinds of comments: Multi-line or single-line
     fn consume_comment(input: &str) -> ParseResult<&str, &str> {
-        let (input, _) = alt((
+        alt((
             Token::consume_shebang_comment,
             Token::consume_single_comment,
             Token::consume_multi_comment,
-        ))(input)?;
-
-        Ok((input, ""))
+        ))(input)
     }
 
     /// Consumes what is considered as "extra": Whitespaces, comments...


### PR DESCRIPTION
Current parser backtraces causing evaluation to run in polynomial time, maybe even exponential time in some cases.
We can rework the grammar to run in linear time, thus drastically increasing performance.