### PR TITLE
Typecheck constants

### DIFF
--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -248,3 +248,54 @@ impl<T> From<T> for JkConstant<T> {
         JkConstant(rust_value)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{JkBool, JkFloat, JkInt};
+
+    use super::*;
+
+    #[test]
+    fn tc_string_type() {
+        let mut ctx = Context::new();
+        let s = JkString::from("that's a jk string");
+
+        assert_eq!(
+            s.resolve_type(&mut ctx),
+            CheckedType::Resolved(TypeId::from("string"))
+        );
+    }
+
+    #[test]
+    fn tc_bool_type() {
+        let mut ctx = Context::new();
+        let s = JkBool::from(false);
+
+        assert_eq!(
+            s.resolve_type(&mut ctx),
+            CheckedType::Resolved(TypeId::from("bool"))
+        );
+    }
+
+    #[test]
+    fn tc_i_type() {
+        let mut ctx = Context::new();
+        let s = JkInt::from(0);
+
+        assert_eq!(
+            s.resolve_type(&mut ctx),
+            CheckedType::Resolved(TypeId::from("int"))
+        );
+    }
+
+    #[test]
+    fn tc_f_type() {
+        let mut ctx = Context::new();
+        let s = JkFloat::from(15.4);
+
+        assert_eq!(
+            s.resolve_type(&mut ctx),
+            CheckedType::Resolved(TypeId::from("float"))
+        );
+    }
+}

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -1,4 +1,5 @@
-use crate::instruction::{InstrKind, Instruction, Operator, TypeDec};
+use crate::instruction::{InstrKind, Instruction, Operator, TypeDec, TypeId};
+use crate::typechecker::{CheckedType, TypeCheck};
 use crate::{
     Context, Error, FromObjectInstance, JkString, ObjectInstance, ToObjectInstance, Value,
 };
@@ -106,6 +107,12 @@ macro_rules! jk_primitive {
                 Some(self.to_instance())
             }
         }
+
+        impl TypeCheck for JkConstant<bool> {
+            fn resolve_type(&self, _: &mut Context) -> CheckedType {
+                CheckedType::Resolved(TypeId::from("bool"))
+            }
+        }
     };
     ($t:ty, $s:expr) => {
         impl ToObjectInstance for JkConstant<$t> {
@@ -150,6 +157,12 @@ macro_rules! jk_primitive {
                 // Since we cannot use the generic ToObjectInstance implementation, we also have to
                 // copy paste our four basic implementations for jinko's primitive types...
                 Some(self.to_instance())
+            }
+        }
+
+        impl TypeCheck for JkConstant<$t> {
+            fn resolve_type(&self, _: &mut Context) -> CheckedType {
+                CheckedType::Resolved(TypeId::from($s))
             }
         }
     };
@@ -215,6 +228,12 @@ impl Instruction for JkString {
         ctx.debug("CONSTANT", &self.0.to_string());
 
         Some(self.to_instance())
+    }
+}
+
+impl TypeCheck for JkString {
+    fn resolve_type(&self, _ctx: &mut Context) -> CheckedType {
+        CheckedType::Resolved(TypeId::from("string"))
     }
 }
 


### PR DESCRIPTION
- typechecker: Add base trait for TypeChecking
- typechecker: Add type_cache macro
- typechecker: Add default() for CheckedType
- typechecker: Add documentation
- typechecker: Fix formatting
- repl: Do not execute if a type error was found
- repl: Emit errors in interactive mode
- typechecker: Remove trait bound on TC for Instructions
- cargo: Update jinko version
- repl: Remove usage of typechecking for now
- binary_op: Remove warnings
- jk_inst: Remove warnings
- typechecker: Remove Typechecker uses for now
- jk_constant: Implement typechecking
