### PR TITLE
typechecker/field access

### DIFF
--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -1,7 +1,12 @@
 //! FieldAccesses represent an access onto a type instance's members.
 //! FIXME: Add doc
 
-use crate::{Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance};
+use crate::{
+    typechecker::{CheckedType, TypeCtx},
+    Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, TypeCheck,
+};
+
+use super::TypeId;
 
 #[derive(Clone)]
 pub struct FieldAccess {
@@ -17,22 +22,9 @@ impl FieldAccess {
             field_name,
         }
     }
-}
 
-impl Instruction for FieldAccess {
-    fn kind(&self) -> InstrKind {
-        // A field access can only ever be an expression, since we cannot store statements
-        // in a type
-        InstrKind::Expression(None)
-    }
-
-    fn print(&self) -> String {
-        format!("{}.{}", self.instance.print(), self.field_name)
-    }
-
-    fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("FIELD ACCESS ENTER", &self.print());
-
+    /// Get a reference to the accessed field's instance
+    fn get_field_instance(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         let calling_instance = match self.instance.execute(ctx) {
             None => {
                 ctx.error(Error::new(ErrKind::Context).with_msg(format!(
@@ -51,9 +43,65 @@ impl Instruction for FieldAccess {
             }
         };
 
+        Some(field_instance)
+    }
+}
+
+impl Instruction for FieldAccess {
+    fn kind(&self) -> InstrKind {
+        // A field access can only ever be an expression, since we cannot store statements
+        // in a type
+        InstrKind::Expression(None)
+    }
+
+    fn print(&self) -> String {
+        format!("{}.{}", self.instance.print(), self.field_name)
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
+        ctx.debug("FIELD ACCESS ENTER", &self.print());
+
+        let field_instance = self.get_field_instance(ctx);
+
         ctx.debug("FIELD ACCESS EXIT", &self.print());
 
-        Some(field_instance)
+        field_instance
+    }
+}
+
+impl TypeCheck for FieldAccess {
+    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+        // FIXME: Wait for trait bound
+        /* self.instance.resolve_type(ctx); */
+        let instance_ty = CheckedType::Resolved(TypeId::new(String::from("CustomType")));
+        let instance_ty_name = match &instance_ty {
+            CheckedType::Resolved(ti) => ti.id(),
+            _ => {
+                ctx.error(Error::new(ErrKind::TypeChecker).with_msg(format!(
+                    "trying to access field `{}` on statement",
+                    self.field_name
+                )));
+                return CheckedType::Unknown;
+            }
+        };
+
+        // We can unwrap here since the type that was resolved from the instance HAS
+        // to exist. If it does not, this is an interpreter error
+        let (_, fields_ty) = ctx.get_custom_type(instance_ty_name).unwrap();
+
+        match fields_ty
+            .iter()
+            .find(|(field_name, _)| *field_name == self.field_name)
+        {
+            Some((_, field_ty)) => field_ty.clone(),
+            None => {
+                ctx.error(Error::new(ErrKind::TypeChecker).with_msg(format!(
+                    "trying to access field `{}` on instance of type `{}`",
+                    self.field_name, instance_ty
+                )));
+                CheckedType::Unknown
+            }
+        }
     }
 }
 

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -72,7 +72,12 @@ impl TypeCheck for TypeDec {
         let fields_ty = self
             .fields
             .iter()
-            .map(|dec_arg| CheckedType::Resolved(dec_arg.get_type().clone()))
+            .map(|dec_arg| {
+                (
+                    dec_arg.name().to_string(),
+                    CheckedType::Resolved(dec_arg.get_type().clone()),
+                )
+            })
             .collect();
         ctx.declare_custom_type(
             self.name.clone(),

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -158,7 +158,7 @@ impl TypeCheck for TypeInstantiation {
         };
 
         let mut errors = vec![];
-        for (field_ty, value_ty) in fields_ty.iter().zip(self.fields.iter().map(
+        for ((_, field_ty), value_ty) in fields_ty.iter().zip(self.fields.iter().map(
             // FIXME: Once trait bound yada yada
             |_var_assign| CheckedType::Void, /* var_assign.value().resolve_type(ctx) */
         )) {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -42,7 +42,7 @@ struct FunctionType {
 
 struct CustomTypeType {
     self_ty: CheckedType,
-    fields_ty: Vec<CheckedType>,
+    fields_ty: Vec<(String, CheckedType)>,
 }
 
 // TODO: Should we factor this into a `Context` trait? All contexts will share some
@@ -112,7 +112,7 @@ impl<'ctx> TypeCtx<'ctx> {
         &mut self,
         name: String,
         self_ty: CheckedType,
-        fields_ty: Vec<CheckedType>,
+        fields_ty: Vec<(String, CheckedType)>,
     ) {
         // We can unwrap since this is an interpreter error if we can't add a new
         // type to the scope map
@@ -137,7 +137,10 @@ impl<'ctx> TypeCtx<'ctx> {
     }
 
     /// Access a previously declared custom type
-    pub fn get_custom_type(&mut self, name: &str) -> Option<(&CheckedType, &Vec<CheckedType>)> {
+    pub fn get_custom_type(
+        &mut self,
+        name: &str,
+    ) -> Option<(&CheckedType, &Vec<(String, CheckedType)>)> {
         self.types
             .get_type(name)
             .map(|custom_type| (&custom_type.self_ty, &custom_type.fields_ty))


### PR DESCRIPTION
- type_declaration: Add missing field in type checking
- typechecker: Keep track of field names in TypeCtx
- field_access: Implement typechecking
