### PR TITLE
Type instantiation and Function calls generics

### DIFF
--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -384,12 +384,14 @@ fn inner_block(input: &str) -> ParseResult<&str, Block> {
     Ok((input, block))
 }
 
-/// func_type_or_var = '(' next func_or_type_inst_args
+/// func_type_or_var = [ '<' IDENTIFIER ( ',' IDENTIFIER )* '>' ] '(' next func_or_type_inst_args
 ///                  | '=' expr                   (* variable assigment *)
 ///                  | ε                          (* variable *)
 fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
-    if let Ok((input, _)) = Token::left_parenthesis(input) {
-        func_or_type_inst_args(next(input), id)
+    if let Ok((input, _)) = Token::lt(input) {
+        generic_func_or_type_inst_args(next(input), id)
+    } else if let Ok((input, _)) = Token::left_parenthesis(input) {
+        func_or_type_inst_args(next(input), id, None)
     } else if let Ok((input, _)) = Token::equal(input) {
         let (input, value) = expr(input)?;
         Ok((input, Box::new(VarAssign::new(false, id, value))))
@@ -400,7 +402,7 @@ fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instru
 
 /// func_or_type_inst_args = IDENTIFIER next ':' expr (',' type_inst_arg )* ')'  (* type_instantiation *)
 ///                  | args                                            (* function_call *)
-fn func_or_type_inst_args(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
+fn func_or_type_inst_args(input: &str, id: String, generics: Option<Vec<TypeId>>) -> ParseResult<&str, Box<dyn Instruction>> {
     if let Ok((input, first_attr)) =
         terminated(terminated(Token::identifier, nom_next), Token::colon)(input)
     {
@@ -412,11 +414,25 @@ fn func_or_type_inst_args(input: &str, id: String) -> ParseResult<&str, Box<dyn 
         type_inst.add_field(VarAssign::new(false, first_attr, first_attr_val));
         attrs.into_iter().for_each(|attr| type_inst.add_field(attr));
 
+        // type_inst.set_generics(_generics);
+
         Ok((input, Box::new(type_inst)))
     } else {
         let (input, args) = args(input)?;
-        Ok((input, Box::new(FunctionCall::new(id, args))))
+        let mut func_call = FunctionCall::new(id, args);
+
+        // func_call.set_generics(_generics);
+
+        Ok((input, Box::new(func_call)))
     }
+}
+
+fn generic_func_or_type_inst_args(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
+    // FIXME: Assign generics to FunctionCall and TypeInstantiation
+    let (input, generics) = generic_list(input)?;
+    let (input, _) = Token::left_parenthesis(input)?;
+
+    func_or_type_inst_args(next(input), id, Some(generics))
 }
 
 ///
@@ -1171,5 +1187,25 @@ func void() { }"##;
     #[test]
     fn func_dec_no_generic_delimiter() {
         assert!(expr("func a[T, U() {}").is_err())
+    }
+
+    #[test]
+    fn func_call_generics_one() {
+        assert!(expr("fn_call<T>()").is_ok());
+    }
+
+    #[test]
+    fn func_call_generics_multi() {
+        assert!(expr("fn_call<T, U, V>()").is_ok());
+    }
+
+    #[test]
+    fn func_call_generics_multi_and_args() {
+        assert!(expr("fn_call<T, U, V>(a, b, c)").is_ok());
+    }
+
+    #[test]
+    fn type_inst_generics_multi_and_args() {
+        assert!(expr("TypeInst<T, U, V>(a: 0, b: 1, c: 2)").is_ok());
     }
 }

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -314,19 +314,19 @@ fn generic_list(input: &str) -> ParseResult<&str, Vec<TypeId>> {
 
     let (input, first_type) = whitespace_plus_id(input)?;
     let (input, mut generics) = many0(preceded(Token::comma, whitespace_plus_id))(input)?;
-    let (input, _) = Token::gt(input)?;
+    let (input, _) = Token::right_bracket(input)?;
 
     generics.insert(0, first_type);
     Ok((input, generics.into_iter().map(TypeId::new).collect()))
 }
 
-/// function_declaration = next IDENTIFIER [ next '<' IDENTIFIER ( ',' IDENTIFIER )* '>' ] next '(' next typed_arg next return_type
+/// function_declaration = next IDENTIFIER [ next '[' IDENTIFIER ( ',' IDENTIFIER )* ']' ] next '(' next typed_arg next return_type
 fn func_declaration(input: &str) -> ParseResult<&str, FunctionDec> {
     let input = next(input);
     let (input, id) = Token::identifier(input)?;
     let input = next(input);
 
-    let (input, _generics) = if let Ok((input, _)) = Token::lt(input) {
+    let (input, _generics) = if let Ok((input, _)) = Token::left_bracket(input) {
         generic_list(input)?
     } else {
         (input, vec![])
@@ -1148,28 +1148,28 @@ func void() { }"##;
 
     #[test]
     fn func_dec_one_generic() {
-        assert!(expr("func a<T>() {}").is_ok())
+        assert!(expr("func a[T]() {}").is_ok())
     }
 
     #[test]
     fn func_dec_multiple_generic() {
-        assert!(expr("func a<T, U, V>() {}").is_ok())
+        assert!(expr("func a[T, U, V]() {}").is_ok())
     }
 
     #[test]
     fn func_dec_generic_and_whitespace() {
-        assert!(expr("func a<    T>() {}").is_ok());
-        assert!(expr("func a<    T  >() {}").is_ok());
-        assert!(expr("func a<   T , U    , V>() {}").is_ok())
+        assert!(expr("func a[    T]() {}").is_ok());
+        assert!(expr("func a[    T  ]() {}").is_ok());
+        assert!(expr("func a[   T , U    , V]() {}").is_ok())
     }
 
     #[test]
     fn func_dec_empty_generic_list() {
-        assert!(expr("func a<>() {}").is_err())
+        assert!(expr("func a[]() {}").is_err())
     }
 
     #[test]
     fn func_dec_no_generic_delimiter() {
-        assert!(expr("func a<T, U() {}").is_err())
+        assert!(expr("func a[T, U() {}").is_err())
     }
 }

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -302,11 +302,36 @@ fn unit_block(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
     Ok((input, Box::new(block)))
 }
 
-/// function_declaration = next IDENTIFIER next '(' next typed_args next return_type
+// FIXME: This does not parse default generic types yet (`func f<T = int>()`)
+fn generic_list(input: &str) -> ParseResult<&str, Vec<TypeId>> {
+    fn whitespace_plus_id(input: &str) -> ParseResult<&str, String> {
+        let input = next(input);
+        let (input, id) = Token::identifier(input)?;
+        let input = next(input);
+
+        Ok((input, id))
+    }
+
+    let (input, first_type) = whitespace_plus_id(input)?;
+    let (input, mut generics) = many0(preceded(Token::comma, whitespace_plus_id))(input)?;
+    let (input, _) = Token::gt(input)?;
+
+    generics.insert(0, first_type);
+    Ok((input, generics.into_iter().map(TypeId::new).collect()))
+}
+
+/// function_declaration = next IDENTIFIER [ next '<' IDENTIFIER ( ',' IDENTIFIER )* '>' ] next '(' next typed_arg next return_type
 fn func_declaration(input: &str) -> ParseResult<&str, FunctionDec> {
     let input = next(input);
     let (input, id) = Token::identifier(input)?;
     let input = next(input);
+
+    let (input, _generics) = if let Ok((input, _)) = Token::lt(input) {
+        generic_list(input)?
+    } else {
+        (input, vec![])
+    };
+
     let (input, _) = Token::left_parenthesis(input)?;
     let input = next(input);
     let (input, args) = typed_args(input)?;
@@ -1119,5 +1144,32 @@ func void() { }"##;
     #[ignore]
     fn expr_with_parenthesis() {
         assert!(expr("lhs + (rhs - lhs)").is_ok())
+    }
+
+    #[test]
+    fn func_dec_one_generic() {
+        assert!(expr("func a<T>() {}").is_ok())
+    }
+
+    #[test]
+    fn func_dec_multiple_generic() {
+        assert!(expr("func a<T, U, V>() {}").is_ok())
+    }
+
+    #[test]
+    fn func_dec_generic_and_whitespace() {
+        assert!(expr("func a<    T>() {}").is_ok());
+        assert!(expr("func a<    T  >() {}").is_ok());
+        assert!(expr("func a<   T , U    , V>() {}").is_ok())
+    }
+
+    #[test]
+    fn func_dec_empty_generic_list() {
+        assert!(expr("func a<>() {}").is_err())
+    }
+
+    #[test]
+    fn func_dec_no_generic_delimiter() {
+        assert!(expr("func a<T, U() {}").is_err())
     }
 }

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -388,7 +388,7 @@ fn inner_block(input: &str) -> ParseResult<&str, Block> {
 ///                  | '=' expr                   (* variable assigment *)
 ///                  | ε                          (* variable *)
 fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
-    if let Ok((input, _)) = Token::lt(input) {
+    if let Ok((input, _)) = Token::left_bracket(input) {
         generic_func_or_type_inst_args(next(input), id)
     } else if let Ok((input, _)) = Token::left_parenthesis(input) {
         func_or_type_inst_args(next(input), id, None)
@@ -402,7 +402,11 @@ fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instru
 
 /// func_or_type_inst_args = IDENTIFIER next ':' expr (',' type_inst_arg )* ')'  (* type_instantiation *)
 ///                  | args                                            (* function_call *)
-fn func_or_type_inst_args(input: &str, id: String, generics: Option<Vec<TypeId>>) -> ParseResult<&str, Box<dyn Instruction>> {
+fn func_or_type_inst_args(
+    input: &str,
+    id: String,
+    generics: Option<Vec<TypeId>>,
+) -> ParseResult<&str, Box<dyn Instruction>> {
     if let Ok((input, first_attr)) =
         terminated(terminated(Token::identifier, nom_next), Token::colon)(input)
     {
@@ -427,7 +431,10 @@ fn func_or_type_inst_args(input: &str, id: String, generics: Option<Vec<TypeId>>
     }
 }
 
-fn generic_func_or_type_inst_args(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
+fn generic_func_or_type_inst_args(
+    input: &str,
+    id: String,
+) -> ParseResult<&str, Box<dyn Instruction>> {
     // FIXME: Assign generics to FunctionCall and TypeInstantiation
     let (input, generics) = generic_list(input)?;
     let (input, _) = Token::left_parenthesis(input)?;
@@ -1191,21 +1198,21 @@ func void() { }"##;
 
     #[test]
     fn func_call_generics_one() {
-        assert!(expr("fn_call<T>()").is_ok());
+        assert!(expr("fn_call[T]()").is_ok());
     }
 
     #[test]
     fn func_call_generics_multi() {
-        assert!(expr("fn_call<T, U, V>()").is_ok());
+        assert!(expr("fn_call[T, U, V]()").is_ok());
     }
 
     #[test]
     fn func_call_generics_multi_and_args() {
-        assert!(expr("fn_call<T, U, V>(a, b, c)").is_ok());
+        assert!(expr("fn_call[T, U, V](a, b, c)").is_ok());
     }
 
     #[test]
     fn type_inst_generics_multi_and_args() {
-        assert!(expr("TypeInst<T, U, V>(a: 0, b: 1, c: 2)").is_ok());
+        assert!(expr("TypeInst[T, U, V](a: 0, b: 1, c: 2)").is_ok());
     }
 }

--- a/src/parser/grammar
+++ b/src/parser/grammar
@@ -51,7 +51,7 @@ block = '{' next inner_block
 inner_block = expr ( ';' expr )* '}'
             | '}'
 
-function_declaration = next IDENTIFIER next '(' next typed_arg next return_type
+function_declaration = next IDENTIFIER [ next '<' IDENTIFIER ( ',' IDENTIFIER )* '>' ] next '(' next typed_arg next return_type
 return_type = '->' next IDENTIFIER next
             | ε
 

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -94,11 +94,11 @@ impl Token {
         Token::specific_char(input, '}')
     }
 
-    pub fn _left_bracket(input: &str) -> ParseResult<&str, char> {
+    pub fn left_bracket(input: &str) -> ParseResult<&str, char> {
         Token::specific_char(input, '[')
     }
 
-    pub fn _right_bracket(input: &str) -> ParseResult<&str, char> {
+    pub fn right_bracket(input: &str) -> ParseResult<&str, char> {
         Token::specific_char(input, ']')
     }
 


### PR DESCRIPTION
- parser: Parse list of generic types in function declarations
- parser: Use '[' and ']' to delimit generics
- parser: Add generics to type instantiation and function calls
- parser: Add generics parsing to function calls and type instantiations
