### PR TITLE
Fix functional tests in new parser

### DIFF
--- a/stdlib/lib.jk
+++ b/stdlib/lib.jk
@@ -7,8 +7,6 @@ incl ffi
 incl shell
 incl args
 
-@dump()
-
 ext func __builtin_exit(exit_code: int);
 
 // FIXME: Add a default value argument here, which defaults to 0

--- a/tests/ft/regression/187_fn.jk
+++ b/tests/ft/regression/187_fn.jk
@@ -3,11 +3,11 @@ mut global_x = 1;
 func mutate_global() {
     func inner() {
         global_x = 0;
-    }
+    };
 
     inner()
 }
 
 mutate_global();
 
-x
+global_x

--- a/tests/ft/stdlib/maybe.jk
+++ b/tests/ft/stdlib/maybe.jk
@@ -1,4 +1,4 @@
-m_manual = Maybe_int { inner = 14, is_nothing = false };
+m_manual = Maybe_int(inner: 14, is_nothing: false);
 m_some = some(15);
 m_nothing = nothing();
 

--- a/tests/ft/type_checking/valid/field_access.jk
+++ b/tests/ft/type_checking/valid/field_access.jk
@@ -1,6 +1,6 @@
 type Point(x: int, y: int, name: string);
 
-p = Point { x = 15, y = 14, name = "p" };
+p = Point(x: 15, y: 14, name: "p");
 
 mut t0 = p.x;
 t0 = 15;

--- a/tests/ft/type_checking/valid/function_complex_type.jk
+++ b/tests/ft/type_checking/valid/function_complex_type.jk
@@ -1,9 +1,9 @@
 type Cinop(lhs: int, rhs: int, op: char);
 
 func new_cinop(lhs: int, rhs: int, op: char) -> Cinop {
-    Cinop { lhs = lhs, rhs = rhs, op = op }
+    Cinop(lhs: lhs, rhs: rhs, op: op)
 }
 
-func execute(self: Cinop) -> int {
+func cinop_execute(self: Cinop) -> int {
     self.lhs + self.rhs
 }

--- a/tests/ft/type_checking/valid/function_type_mapping.jk
+++ b/tests/ft/type_checking/valid/function_type_mapping.jk
@@ -6,4 +6,4 @@ func type_function_args(first: int, sec: string, third: bool) -> int {
     first_copy + first
 }
 
-type_function_args(15, "14", false);
+a = type_function_args(15, "14", false);

--- a/tests/ft/type_checking/valid/return_in_if_else.jk
+++ b/tests/ft/type_checking/valid/return_in_if_else.jk
@@ -1,5 +1,5 @@
 if true {
-    return 1
+    return 1;
 } else {
-    return 2
+    return 2;
 }


### PR DESCRIPTION
- stdlib: Remove extraneous @dump() instruction
- 187_fn: Fix block syntax for inner function declaration
- maybe: Adapt code to new type instantiation syntax
- field_access: Use new type instantiation syntax
- cinop: Use new type instantiation syntax
- type_mapping: New block syntax returns value despite semicolon, adapt test
- if_else: Fix syntax in if_else return test
