### PR TITLE
Add `--no-std` option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -13,6 +13,9 @@ pub struct Args {
     #[structopt(short, long)]
     interactive: bool,
 
+    #[structopt(long = "no-std")]
+    nostdlib: bool,
+
     #[structopt(short, long)]
     debug: bool,
 
@@ -50,6 +53,11 @@ impl Args {
     /// Is the context launched in debug mode
     pub fn debug(&self) -> bool {
         self.debug
+    }
+
+    /// Is the context launched without stdlib
+    pub fn nostdlib(&self) -> bool {
+        self.nostdlib
     }
 
     /// Arguments given to the program

--- a/src/context.rs
+++ b/src/context.rs
@@ -80,24 +80,8 @@ impl Context {
         ep
     }
 
-    /// Create a new context, including the standard library
-    pub fn new() -> Context {
-        let mut ctx = Context::empty();
-
-        // Include the standard library
-        let mut stdlib_incl =
-            crate::instruction::Incl::new(String::from("stdlib"), Some(String::from("")));
-        stdlib_incl.set_base(PathBuf::new());
-        // FIXME: Remove unwrap
-        ctx.entry_point
-            .add_instruction(Box::new(stdlib_incl))
-            .unwrap();
-
-        ctx
-    }
-
     /// Create a new empty context without the standard library
-    pub fn empty() -> Context {
+    pub fn new() -> Context {
         let mut ctx = Context {
             debug_mode: false,
             entry_point: Self::new_entry(),
@@ -353,6 +337,17 @@ impl Context {
     pub fn libs(&self) -> &Vec<libloading::Library> {
         &self.external_libs
     }
+
+    /// Includes the standard library in the context
+    pub fn init_stdlib(&mut self) -> Result<(), Error> {
+        let mut stdlib_incl =
+            crate::instruction::Incl::new(String::from("stdlib"), Some(String::from("")));
+        stdlib_incl.set_base(PathBuf::new());
+
+        self.entry_point.add_instruction(Box::new(stdlib_incl))?;
+
+        Ok(())
+    }
 }
 
 /// Printer for the context's usage of the ScopeMap
@@ -414,6 +409,7 @@ mod tests {
     #[test]
     fn t_print_scopemap() {
         let mut ctx = Context::new();
+        ctx.init_stdlib().unwrap();
         ctx.execute().unwrap();
 
         let output = format!("{}", ctx.scope_map);

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn handle_input(args: &Args, file: &Path) -> InteractResult {
     let input = fs::read_to_string(file)?;
 
     let mut ctx = Context::new();
+    ctx.init_stdlib()?;
 
     Parser::parse(&mut ctx, &input)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,10 @@ fn handle_exit_code(result: Option<ObjectInstance>) -> ! {
 fn handle_input(args: &Args, file: &Path) -> InteractResult {
     let input = fs::read_to_string(file)?;
 
-    let mut ctx = Parser::parse(&input)?;
+    let mut ctx = Context::new();
+
+    Parser::parse(&mut ctx, &input)?;
+
     ctx.set_path(Some(file.to_owned()));
     ctx.set_args(args.project_args());
     ctx.set_debug(args.debug());

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,10 @@ fn handle_input(args: &Args, file: &Path) -> InteractResult {
     let input = fs::read_to_string(file)?;
 
     let mut ctx = Context::new();
-    ctx.init_stdlib()?;
+
+    if !args.nostdlib() {
+        ctx.init_stdlib()?;
+    }
 
     Parser::parse(&mut ctx, &input)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,9 +23,7 @@ pub struct Parser;
 impl Parser {
     /// Parses the entire user input and returns a hashmap corresponding to the user
     /// program
-    pub fn parse(input: &str) -> Result<Context, Error> {
-        let mut ctx = Context::new();
-
+    pub fn parse(ctx: &mut Context, input: &str) -> Result<(), Error> {
         let entry_block = ctx.entry_point.block_mut().unwrap();
 
         let (_, instructions) = Construct::many_instructions(input)?;
@@ -42,6 +40,6 @@ impl Parser {
             }
         }
 
-        Ok(ctx)
+        Ok(())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,8 @@ pub use stack::Stack;
 
 #[macro_export]
 macro_rules! jk_parse {
-    ($($tokens:tt)*) => {
-        $crate::Parser::parse(stringify!($($tokens)*)).unwrap()
+    ($ctx:expr, $($tokens:tt)*) => {
+        $crate::Parser::parse($ctx, stringify!($($tokens)*)).unwrap()
     }
 }
 
@@ -17,7 +17,9 @@ macro_rules! jk_parse {
 macro_rules! jinko {
     ($($tokens:tt)*) => {
         {
-            let mut ctx = $crate::jk_parse! { $($tokens)* };
+            let mut ctx = $crate::Context::new();
+
+            $crate::jk_parse!(&mut ctx, $($tokens)*);
 
             ctx.emit_errors();
             assert!(ctx.execute().is_ok());
@@ -32,7 +34,9 @@ macro_rules! jinko {
 macro_rules! jinko_fail {
     ($($tokens:tt)*) => {
         {
-            let mut ctx = $crate::jk_parse! { $($tokens)* };
+            let mut ctx = $crate::Context::new();
+
+            $crate::jk_parse! (&mut ctx, $($tokens)*);
 
             ctx.emit_errors();
             assert!(ctx.execute().is_err());
@@ -46,7 +50,12 @@ macro_rules! jinko_fail {
 #[macro_export]
 macro_rules! jk_execute {
     ($($tokens:tt)*) => {
-        $crate::Parser::parse(stringify!($($tokens)*)).unwrap().execute().unwrap();
+        {
+            let mut ctx = $crate::Context::new();
+            $crate::Parser::parse(&mut ctx, stringify!($($tokens)*)).unwrap();
+
+            ctx.execute().unwrap()
+        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,7 @@ macro_rules! jinko {
     ($($tokens:tt)*) => {
         {
             let mut ctx = $crate::Context::new();
+            ctx.init_stdlib().unwrap();
 
             $crate::jk_parse!(&mut ctx, $($tokens)*);
 
@@ -35,6 +36,7 @@ macro_rules! jinko_fail {
     ($($tokens:tt)*) => {
         {
             let mut ctx = $crate::Context::new();
+            ctx.init_stdlib().unwrap();
 
             $crate::jk_parse! (&mut ctx, $($tokens)*);
 
@@ -52,6 +54,8 @@ macro_rules! jk_execute {
     ($($tokens:tt)*) => {
         {
             let mut ctx = $crate::Context::new();
+            ctx.init_stdlib().unwrap();
+
             $crate::Parser::parse(&mut ctx, stringify!($($tokens)*)).unwrap();
 
             ctx.execute().unwrap()

--- a/tests/ft/stdlib/stdlib.yml
+++ b/tests/ft/stdlib/stdlib.yml
@@ -50,3 +50,9 @@ tests:
     args:
       - "tests/ft/stdlib/exit.jk"
     exit_code: 42
+  - name: "Test --no-std"
+    binary: "target/debug/jinko"
+    args:
+      - "--no-std"
+      - "tests/ft/stdlib/range/advance.jk"
+    exit_code: 1


### PR DESCRIPTION
Closes #234.

This adds the `-no-std` flag to jinko. In order to do this, the context creation had to be moved out of the parsing function.