### PR TITLE
Only fail token parsing if alphanum_ is next

### DIFF
--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -619,6 +619,14 @@ mod tests {
     }
 
     #[test]
+    fn method_call_on_bool() {
+        let (input, expr) = expr("true.call( )").unwrap();
+
+        assert!(expr.downcast_ref::<MethodCall>().is_some());
+        assert_eq!(input, "");
+    }
+
+    #[test]
     fn field_access_single() {
         let (input, expr) = expr("a.attribute").unwrap();
 


### PR DESCRIPTION
Fixes #340.

Only accept tokens that match and don't have an alphanumeric or `_` character after.