### PR TITLE
docker: add basic Dockerfile to run jinko interpreter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build the jinko interpreter
+# ---------------------------
+
+FROM rust:slim-bullseye as build
+
+COPY . /jinko
+WORKDIR /jinko
+RUN ./install.sh
+
+# ENTRYPOINT ["/root/.jinko/bin/jinko"]
+
+# Run the jinko interpreter in a fresh container
+# ----------------------------------------------
+
+FROM archlinux:latest
+
+COPY --from=build /root/.jinko/bin/jinko /jinko
+
+ENTRYPOINT ["/jinko"]
+
+LABEL maintainer="Tanguy Segarra <tanguy.segarra@epita.fr>"


### PR DESCRIPTION
This is just a simple Dockerfile to run the jinko interpreter directly.

I tried splitting it in two (one layer for build, and one for run) but without any success, I guess the binary cannot be run without rust libraries.

Tell me what you think and I shall adjust my pull request to please your needs.